### PR TITLE
Temporary workaround for secondary monitors on MacOS

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -57,3 +57,39 @@ function addUrlPattern (clickEvent, value) {
   document.getElementById('urlPanel').appendChild(newInput)
   document.getElementById('urlPanel').appendChild(newBtn)
 }
+
+/**
+ * Temporary workaround for secondary monitors on MacOS where redraws don't happen
+ * @See https://bugs.chromium.org/p/chromium/issues/detail?id=971701
+ */
+ if (
+  window.screenLeft < 0 ||
+  window.screenTop < 0 ||
+  window.screenLeft > window.screen.width ||
+  window.screenTop > window.screen.height
+) {
+  chrome.runtime.getPlatformInfo(function (info) {
+    if (info.os === 'mac') {
+      const fontFaceSheet = new CSSStyleSheet()
+      fontFaceSheet.insertRule(`
+        @keyframes redraw {
+          0% {
+            opacity: 1;
+          }
+          100% {
+            opacity: .99;
+          }
+        }
+      `)
+      fontFaceSheet.insertRule(`
+        html {
+          animation: redraw 1s linear infinite;
+        }
+      `)
+      document.adoptedStyleSheets = [
+        ...document.adoptedStyleSheets,
+        fontFaceSheet,
+      ]
+    }
+  })
+}


### PR DESCRIPTION
Found a workaround on the chromium bug thread: https://bugs.chromium.org/p/chromium/issues/detail?id=971701

Basically, forcing the popup to redraw by having an infinite animation. It should only apply to macOS when outside the "normal" screen coordinates (secondary monitor)